### PR TITLE
Allow for custom sources of bank holidays

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,28 @@
+name: Audit
+on:
+  push:
+    paths:
+      - '.github/workflows/audit.yml'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '**/audit.toml'
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Audit dependencies
+        uses: actions-rust-lang/audit@v1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,9 +3,7 @@ on:
   push:
     paths:
       - '.github/workflows/audit.yml'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '**/audit.toml'
+      - 'Cargo.toml'
   schedule:
     - cron: '0 9 * * 1'
   workflow_dispatch:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,6 +9,15 @@ on:
       - published
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CARGO_TERM_VERBOSE: 'true'
+
 jobs:
   test:
     name: Test
@@ -17,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install just
         run: cargo install just
       - name: Run unit tests
@@ -30,7 +39,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
       - name: Install just
@@ -38,10 +47,25 @@ jobs:
       - name: Lint code
         run: just lint
 
+  check-semver:
+    name: Check semver changes
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install just
+        run: cargo install just
+      - name: Check semver changes
+        run: just semver
+
   publish:
     name: Publish crate
     runs-on: ubuntu-latest
     needs:
+      - check-semver
       - test
       - lint
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -49,7 +73,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Publish to crates.io
         run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
         env:

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,18 @@ docs *args:
     rm -rf target/doc
     cargo doc --lib --no-deps {{ args }}
 
+# audit dependencies
+audit *args:
+    cargo install cargo-audit
+    cargo audit {{ args }}
+
+# check semver changes
+semver *args:
+    cargo install cargo-semver-checks
+    cargo semver-checks check-release --default-features {{ args }}
+    cargo semver-checks check-release --only-explicit-features --features chrono {{ args }}
+    cargo semver-checks check-release --only-explicit-features --features time {{ args }}
+
 # clean built binaries and dependencies
 clean:
     cargo clean

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Developing library
 
 - Update version in `Cargo.toml`
 - Add to [History](#history) with changes since last release
-- Tag and publish a release on GitHub which triggers publishing to [crates.io](http://crates.io/crates/govuk-bank-holidays)
+- Tag and [publish a release on GitHub](https://github.com/ministryofjustice/govuk-bank-holidays-rs/releases)
+  which triggers publishing to [crates.io](http://crates.io/crates/govuk-bank-holidays)
 
 TODO
 ----

--- a/README.md
+++ b/README.md
@@ -52,11 +52,7 @@ TODO
 - Better tests, coverage
 - Optionally merge in older known bank holidays into newly-downloaded GOV.UK data? Cached data starts in 2012,
   but currently GOV.UK provides nothing before 2018.
-- Improve GitHub Actions pipeline
-  - Put test, lint & publish steps into 1 job for better reuse of downloaded toolchain and build caches?
-  - Use `cargo-semver-checks`
 - Performance improvements (particularly around memory and iterators)
-- Relax rust version restriction (MSRV)?
 - Can `DataSource` be made private, exposing methods on `LoadDataSource` trait or elsewhere?
 - Allow for unknown “divisions”? Make enum non-exhaustive?
 

--- a/src/data_source/cached.rs
+++ b/src/data_source/cached.rs
@@ -1,4 +1,5 @@
-use super::DataSource;
+use crate::Error;
+use super::{DataSource, LoadDataSource};
 
 /// Built-in list of bank holidays used as a backup, in testing or when network requests are not available.
 pub struct Cached;
@@ -10,5 +11,12 @@ impl Cached {
         const CACHED_DATA: &[u8] = include_bytes!("bank-holidays.json");
         DataSource::try_from_json(CACHED_DATA)
             .expect("cached data should be valid")
+    }
+}
+
+impl LoadDataSource for Cached {
+    #[inline]
+    async fn load_data_source(&self) -> Result<DataSource, Error> {
+        Ok(Cached::cached_data_source())
     }
 }

--- a/src/data_source/reqwest.rs
+++ b/src/data_source/reqwest.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use super::DataSource;
+use super::{DataSource, LoadDataSource};
 
 /// Loads bank holidays from a URL in JSON format.
 /// Uses the `reqwest` client.
@@ -34,5 +34,11 @@ impl<'a> Reqwest<'a> {
                 data_source
             })
             .map_err(Error::from)
+    }
+}
+
+impl<'a> LoadDataSource for Reqwest<'a> {
+    async fn load_data_source(&self) -> Result<DataSource, Error> {
+        self.load_data_source().await
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,4 +14,8 @@ pub enum Error {
     /// Date is invalid.
     #[error("Invalid date")]
     InvalidDate,
+
+    /// Another kind of error – useful for custom [`LoadDataSource`](crate::data_source::LoadDataSource) implementations.
+    #[error("{0}")]
+    Generic(&'static str),
 }


### PR DESCRIPTION
The initial version allowed constructing a calendar from a `DataSource` but this can be generalised with a trait.

Note that the `LoadDataSource` trait has an async method which
1) is only allowed on stable rust 1.75+
2) does not (yet) allow specifying auto trait bounds – this should not matter much as external code is only expected to implement it and these bounds probably do not matter in the calendar-loading method