### PR TITLE
Log to stderr in example binaries because that’s the sensible convention

### DIFF
--- a/examples/bank-holidays.rs
+++ b/examples/bank-holidays.rs
@@ -1,4 +1,5 @@
 //! Demo command line tool that uses the bank holiday library
+use std::io::stderr;
 
 use tracing_subscriber::{EnvFilter, filter::LevelFilter, prelude::*};
 
@@ -7,7 +8,8 @@ use govuk_bank_holidays::prelude::*;
 #[tokio::main]
 async fn main() {
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::fmt::layer()
+            .with_writer(stderr))
         .with(EnvFilter::builder()
             .with_default_directive(LevelFilter::DEBUG.into())
             .from_env_lossy())

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -6,7 +6,7 @@
 //! ```
 
 use std::fs::File;
-use std::io::{BufReader, Write};
+use std::io::{BufReader, stderr, Write};
 use std::path::Path;
 
 use tracing_subscriber::{EnvFilter, filter::LevelFilter, prelude::*};
@@ -17,7 +17,8 @@ use govuk_bank_holidays::data_source::DataSource;
 #[tokio::main]
 async fn main() {
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::fmt::layer()
+            .with_writer(stderr))
         .with(EnvFilter::builder()
             .with_default_directive(LevelFilter::DEBUG.into())
             .from_env_lossy())


### PR DESCRIPTION
…but oddly is not `tracing-subscriber`’s default